### PR TITLE
adds a pipe and traverse method to visitors

### DIFF
--- a/lib/mahuta/visitor.rb
+++ b/lib/mahuta/visitor.rb
@@ -32,6 +32,15 @@ module Mahuta
         send "leave_#{node.node_type}", *[node, depth][0...method("leave_#{node.node_type}").arity] # TODO Write a test for that!!!
       end
     end
+
+    def traverse(tree) 
+      tree.traverse(self)
+      self
+    end
+
+    def pipe(visitor)
+      visitor.traverse(self.result)
+    end
     
   end
   


### PR DESCRIPTION
allows us to chain visitors more succinctly: 

```ruby

result = some_visitor.traverse(a_tree).pipe(another_visitor).pipe(yet_another_visitor).result

```